### PR TITLE
After uploading a certificate to IAM in an earlier Chef recipe, it

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -3,4 +3,4 @@ maintainer_email "jesse@websterclay.com"
 license          "Apache 2.0"
 description      "Configure Elastic Load Balancers at AWS"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "0.1"
+version          "0.1.1"

--- a/providers/load_balancer.rb
+++ b/providers/load_balancer.rb
@@ -37,6 +37,8 @@ end
 
 action :create do
   ruby_block "Create ELB #{new_resource.lb_name}" do
+    retries     new_resource.retries
+    retry_delay 10
     block do
       elb.create_load_balancer(new_resource.availability_zones, new_resource.lb_name, new_resource.listeners)
       data = nil
@@ -48,6 +50,7 @@ action :create do
             sleep 3
           end
         end
+      rescue Fog::AWS::IAM::NotFound
       rescue Timeout::Error
         raise "Timed out waiting for ELB data after #{new_resource.timeout} seconds"
       end

--- a/resources/load_balancer.rb
+++ b/resources/load_balancer.rb
@@ -9,3 +9,4 @@ attribute :listeners,             :kind_of => Array,  :default => [{"InstancePor
 attribute :instances,             :kind_of => Array
 attribute :search_query,          :kind_of => String
 attribute :timeout,                                   :default => 60
+attribute :retries,               :kind_of => Integer, :default => 20


### PR DESCRIPTION
is seldom found by the load_balancer provider until up to a few minutes
have passed.

This change allows for us to retry until we see the certificate.
